### PR TITLE
Fixing dustbunny to correspond with newer versions of hypothesis

### DIFF
--- a/dustbunny/generate.py
+++ b/dustbunny/generate.py
@@ -17,7 +17,7 @@ class Generate(object):
         g.execute()
         
     """
-    def __init__(self, db, model, create_func=None):
+    def __init__(self, db, model, create_func=None, deadline=200):
         if create_func:
             self.create = create_func
         else:
@@ -33,6 +33,7 @@ class Generate(object):
         self.relative_values = []
         self.extras = {}
         self.generated_instances = []
+        self.deadline = deadline
 
     def with_extras(self, **kwargs):
         """
@@ -85,7 +86,7 @@ class Generate(object):
             
         recs = []
             
-        @settings(max_examples=k)
+        @settings(max_examples=k, deadline=self.deadline)
         def gen(**kwargs):
             rels = {}
             for rv in self.relative_values:
@@ -115,7 +116,7 @@ class Generate(object):
         ret.dist = dist
         
         return ret
-    
+
     def for_every(self, *args):
         """
         Generates child instances, one for every permutation of args.

--- a/dustbunny/hyp/strategies.py
+++ b/dustbunny/hyp/strategies.py
@@ -3,10 +3,15 @@ Define a bounded date strategy for Hypothesis.
 """
 
 from hypothesis.errors import InvalidArgument
-from hypothesis.searchstrategy import SearchStrategy
-from hypothesis.strategies import defines_strategy, composite
+from hypothesis.strategies import composite
+from hypothesis.strategies._internal import SearchStrategy
+from hypothesis.strategies._internal.core import base_defines_strategy
 from hypothesis import assume, strategies as st
 import hypothesis.internal.conjecture.utils as cu
+
+# cstump dev note: things get gross here
+from hypothesis.strategies._internal import SearchStrategy
+from hypothesis.strategies._internal.core import base_defines_strategy
 
 import pytz
 import datetime as dt
@@ -28,6 +33,8 @@ __all__ = (
     'alphanumeric',
     'datetimes_in_range',
 )
+
+defines_strategy = base_defines_strategy(False)
 
 words = partial(st.text, alphabet=WORDCHARS)
 alphanumeric = partial(st.text, alphabet=ALPHANUM)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.3.0',
+    version='1.3.2',
 
     description='Generate database records for fuzz testing using SQLAlchemy',
     long_description=long_description,


### PR DESCRIPTION
So basically newer versions of hypothesis (anything >= 5) will break with dustbunny's current code.  Few things I did to fix this:

* For dustbunny's Generate class I made it so that it can take an optional init parameter called `deadline`, which corresponds to the hypothesis deadline in milliseconds.  I set it to the hypothesis default (200).
* For dustbunny's strategies, I had to change how we're importing SearchStrategy and defines_strategy from hypothesis, as those are now in a private internal part of hypothesis.  It's a little gross and can break at any time in the future, but it works for now and gives us some time to fix things down the line.
* I also went ahead and bumped the version number to 1.3.2, as the latest on pypi is 1.3.1.